### PR TITLE
fix: use fixed default port 45678 instead of random

### DIFF
--- a/webui/main.go
+++ b/webui/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"math/rand"
 	"net/http"
 	"strconv"
 
@@ -18,7 +17,7 @@ var Port = 0
 // Start the webui
 func Start() {
 	if SPort == "0" {
-		Port = 2000 + rand.Intn(10000)
+		Port = 45678
 	} else {
 		Port, _ = strconv.Atoi(SPort)
 	}


### PR DESCRIPTION
## Summary

- Replace the random port selection (`2000 + rand.Intn(10000)`) with a fixed default of `45678`
- Port 45678 sits above the range used by common development tools and well below the OS ephemeral port range (49152+), minimising collision risk
- The existing `SPort` override mechanism is unchanged — users who need a custom port can still set it

## Motivation

A random port on every restart makes it impossible to bookmark the app or use stable URLs. A fixed default gives a reliable entry point with no configuration needed.

## Test plan

- [ ] Build and run with no `SPort` set — server starts on `45678`
- [ ] Build and run with `SPort` set to another value — server uses that value instead
- [ ] Confirm `rand` import removed (no longer needed)